### PR TITLE
Update go.mod golang.org/x/crypto version to patch authentication bypass by capture-replay vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/Code-Hex/go-infinity-channel v1.0.0
-	golang.org/x/crypto v0.1.0
+	golang.org/x/crypto v0.18.0
 	golang.org/x/mod v0.6.0
 )
 


### PR DESCRIPTION
Bump version of golang.org/x/crypto to 0.18.0 to address authentication bypass vulnerability.

Ticket: https://github.com/Code-Hex/vz/issues/152

This PR bumps the version of a vulnerable package.

## Which issue(s) this PR fixes:
Fixes #https://github.com/Code-Hex/vz/issues/152

## Additional documentation

Defect identified by snyk.io scanner